### PR TITLE
Release v0.10.1 - minors

### DIFF
--- a/etg/__version__.py
+++ b/etg/__version__.py
@@ -1,7 +1,7 @@
 __title__ = 'etg'
 __description__ = 'ETG API v3 Python SDK'
 __url__ = ''
-__version__ = '0.10.0'
+__version__ = '0.10.1'
 __author__ = 'Sergey Popinevskiy'
 __author_email__ = 'sergey.popinevskiy@gmail.com'
 __license__ = 'MIT'

--- a/etg/client.py
+++ b/etg/client.py
@@ -5,9 +5,6 @@ import requests
 from requests.auth import HTTPBasicAuth
 
 from .models.client import Response
-from .models.hotels import (
-    GuestData,
-)
 
 
 class ETGClient:
@@ -90,7 +87,7 @@ class ETGClient:
 
 class MultiJSONEncoder(json.JSONEncoder):
     def default(self, o):
-        if isinstance(o, GuestData):
+        if hasattr(o, 'to_json') and callable(o.to_json):
             return o.to_json()
         # Let the base class default raise the TypeError
         return json.JSONEncoder.default(self, o)

--- a/etg/hotels.py
+++ b/etg/hotels.py
@@ -94,8 +94,9 @@ class ETGHotelsClient(ETGClient):
         :type checkin: datetime.date
         :param checkout: check-out date, no later than 30 days from check-in date.
         :type checkout: datetime.date
-        :param guests: list of guests in the rooms, e.g. [{'adults': 2, 'children': []}].
+        :param guests: list of guests in the rooms.
             The max number of rooms in one request is 6.
+        :type guests: list[GuestData]
         :param kwargs: optional parameters.
             For more information, see the description of ``self.search`` method.
         :return: list of available hotels (Hotels Search Engine Results Page).
@@ -112,8 +113,9 @@ class ETGHotelsClient(ETGClient):
         :type checkin: datetime.date
         :param checkout: check-out date, no later than 30 days from check-in date.
         :type checkout: datetime.date
-        :param guests: list of guests in the rooms, e.g. [{'adults': 2, 'children': []}].
+        :param guests: list of guests in the rooms.
             The max number of rooms in one request is 6.
+        :type guests: list[GuestData]
         :param kwargs: optional parameters.
             For more information, see the description of ``self.search`` method.
         :return: list of available hotels (Region Search Engine Results Page).


### PR DESCRIPTION
- Redesigned `MultiJSONEncoder.default()` to use it for all models with the `to_json()` function.
- Fixed description for search methods.